### PR TITLE
Unnecessary boxing of byte to Byte

### DIFF
--- a/projects/jasn1/src/main/java/com/beanit/jasn1/ber/BerTag.java
+++ b/projects/jasn1/src/main/java/com/beanit/jasn1/ber/BerTag.java
@@ -147,7 +147,7 @@ public class BerTag implements Serializable {
    */
   public int decodeAndCheck(InputStream is) throws IOException {
 
-    for (Byte identifierByte : tagBytes) {
+    for (byte identifierByte : tagBytes) {
       int nextByte = is.read();
       if (nextByte == -1) {
         throw new EOFException("Unexpected end of input stream.");


### PR DESCRIPTION
Is there any particular reason to box the Bytes for the for-loop?
Seems a bit unnecessary, although the JVM will probably inline this.

```
  public int decodeAndCheck(java.io.InputStream) throws java.io.IOException;
    Code:
       0: aload_0
       1: getfield      #2                  // Field tagBytes:[B
       4: astore_2
       5: aload_2
       6: arraylength
       7: istore_3
       8: iconst_0
       9: istore        4
      11: iload         4
      13: iload_3
      14: if_icmpge     78
      17: aload_2
      18: iload         4
      20: baload
      21: invokestatic  #18                 // Method java/lang/Byte.valueOf:(B)Ljava/lang/Byte;
      24: astore        5
      26: aload_1
      27: invokevirtual #11                 // Method java/io/InputStream.read:()I
```

vs

```
  public int decodeAndCheck(java.io.InputStream) throws java.io.IOException;
    Code:
       0: aload_0
       1: getfield      #2                  // Field tagBytes:[B
       4: astore_2
       5: aload_2
       6: arraylength
       7: istore_3
       8: iconst_0
       9: istore        4
      11: iload         4
      13: iload_3
      14: if_icmpge     72
      17: aload_2
      18: iload         4
      20: baload
      21: istore        5
      23: aload_1
      24: invokevirtual #11                 // Method java/io/InputStream.read:()I
```